### PR TITLE
CTECH-1554: Removes code used when testing locally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,15 +22,3 @@ services:
       - FBN_ACCESS_TOKEN
     volumes:
       - .:/usr/src
-      - ~/src/local-packages:/tmp/packages
-    entrypoint: /bin/bash
-    command:
-      - -ce
-      - |
-        cd /usr/src
-        echo "HERE!!!!"
-        ls /tmp/packages/
-        echo "DONE WITH THE LS>"
-        pip install /tmp/packages/lusid-notifications-sdk-preview-0.1.500.tar.gz
-        pip list
-        PYTHONPATH=/usr/src/ python runner/run.py 


### PR DESCRIPTION
Left behind some artefacts when doing the testing earlier. This PR removes those so as to fix the PR build/test cycle.

Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>