### PR TITLE
CTECH-1903: Pins version of sdks < 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ jsonschema==3.2.0
 colorama~=0.4.4
 chevron==0.14.0
 
-lusid-drive-sdk-preview <= 1.0
-lusid-notifications-sdk-preview <= 1.0
+lusid-drive-sdk-preview < 2
+lusid-notifications-sdk-preview < 2
 finbourne-sdk-utilities >= 0.0.10
-dve-lumipy-preview <= 1.0
-lusid-sdk-preview >= 0.11.4713, <= 1.0
+dve-lumipy-preview < 2
+lusid-sdk-preview >= 0.11.4713, < 2


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

Upcoming changes to the the generator for the sdk's might break compatibility. This pins the version of the finbourne sdks so that this package will not break in such an event.

The premise previously had been that pinning to <= 1.0 would still allow us to update patch versions `1.0.x`  however that is not true, so now pinning `< 2`