### PR TITLE
updated luminesce sdk requirement

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         id: run_tests
         env:
-          FBN_BASE_API_URL: ${{ secrets.FBN_BASE_API_URL }}
+          FBN_BASE_API_URL: ${{ secrets.URI }}
           FBN_ACCESS_TOKEN: ${{ secrets.TOKEN }}
         run: |
           echo "env variables have been set"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         id: run_tests
         env:
-          FBN_BASE_API_URL: ${{ secrets.URI }}
+          FBN_BASE_API_URL: ${{ secrets.FBN_BASE_API_URL }}
           FBN_ACCESS_TOKEN: ${{ secrets.TOKEN }}
         run: |
           echo "env variables have been set"

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -35,6 +35,6 @@ jobs:
         run: |
             echo "env variables for MASTER have been set"
             pip install -r requirements.txt
-            pip install dve-lumipy-preview --no-dependencies
+            pip install dve-lumipy-preview==0.1.89 --no-dependencies
             echo "Running the tests..."
             python runner/run.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ lusid-notifications-sdk-preview < 2
 finbourne-sdk-utilities >= 0.0.10
 lusid-sdk-preview >= 0.11.4713, < 2
 luminesce-sdk-preview==1.14.510
+lusid-jam

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ lusid-drive-sdk-preview < 2
 lusid-notifications-sdk-preview < 2
 finbourne-sdk-utilities >= 0.0.10
 lusid-sdk-preview >= 0.11.4713, < 2
-luminesce-sdk-preview==1.13.935
+luminesce-sdk-preview==1.14.510


### PR DESCRIPTION
chronjob build failing, luminesce sdk version has been pinpointed as the cause. Updating the the value and conducting a test run.

I tried running this locally to no avail, was told that I should just open a pr with the changes to see if the build passes

Success pending...